### PR TITLE
…

### DIFF
--- a/qarpo/__init__.py
+++ b/qarpo/__init__.py
@@ -6,4 +6,3 @@ from .telemetry_dashboard import *
 from .multiversion_links import *
 from .control_widgets import *
 from .query_nodes import *
-

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="qarpo",
-    version="1.0.33",
+    version="1.0.34",
     author="AlaaEltablawy",
     author_email="alaa@colfax-intl.com",
     description="Jyputer interface for job preparation and submission to job scheduler, Check repo status and refresh repo",


### PR DESCRIPTION
Added parameter to check all queues, instead of only the provided queue. Adds additional qstat queries to determine if a job has started after the DashboardLauncher class has been initialized. Added code to handle start_time missing error when re-running initialization. Incremented version number.

Validation Steps:
1) Single Link Configuration
    a) In dlworkbench.py, set the reopen_msg parameter to empty string ('').
    b) Run the code block and click the 'Start Application' button.
    c) Verify that only 1 link is presented on the page.
2) Reset Support (Requires DLWorkbenchLauncher.ipynb with 2 DashboardLauncher code blocks)
   2.1: Clear workbench
       a) Run the second code block that executes LaunchDashboard with queue workbench2 and click 'Start Application'
       b) Verify the link is created 
       c) Verify that the .production, .workbench, and .dev_cloud_service were removed
       d) Clicking the link will recreate the files
    2.2: Verify no new queues are created
       a) Run the first code block and click 'Start Application'
       b) Run the second code block and verify button states 'Stop Application' indicating running the second code block found the queue/job number from the first code block.
       c) Click stop application, verify that the message below both code blocks states the job was terminated.