### PR TITLE
Fix for Telemetry Button - qarpo 1.0.35

### DIFF
--- a/qarpo/control_widgets.py
+++ b/qarpo/control_widgets.py
@@ -51,17 +51,20 @@ class ControlWidget(Interface):
     
     def addTelemetryButton(self):
         telemetry_button = widgets.Button(description='Dashboard', disabled=False, button_style='info')
-        telemetry_status = widgets.HTML(value = "")
-        telemetry_box = widgets.VBox([telemetry_button, telemetry_status])
+        telemetry_out = widgets.Output()
+        telemetry_box = widgets.VBox([telemetry_button, telemetry_out])
 
         def displayTelemetry(event):
                 if self.Int_obj.jobStillRunning(self.command):
-                    telemetry_status.value = "Telemetry results are not ready yet"
+                    with telemetry_out:
+                        telemetry_out.clear_output()
+                        status = "<p>Telemetry results are not ready yet</p>"
+                        display(HTML ('''{}'''.format(status)))
                 else:
-                    telemetry_status.value = ""
-                    URL = "https://devcloud.intel.com/edge/metrics/d/"+self.jobDict[self.command]['jobid']
-                    script=f"<script>var win = window.open('{URL}', '_blank');</script>"
-                    display(HTML ('''{}'''.format(script)))
+                    with telemetry_out:
+                        URL = "https://devcloud.intel.com/edge/metrics/d/"+self.jobDict[self.command]['jobid']
+                        script=f"<script>var win = window.open('{URL}', '_blank');</script>"
+                        display(HTML ('''{}'''.format(script)))
         telemetry_button.on_click(displayTelemetry)
         return telemetry_box
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="qarpo",
-    version="1.0.34",
+    version="1.0.35",
     author="AlaaEltablawy",
     author_email="alaa@colfax-intl.com",
     description="Jyputer interface for job preparation and submission to job scheduler, Check repo status and refresh repo",


### PR DESCRIPTION
Steps to reproduce the issue with qarpo version 1.0.34:

1) Go to https://devcloud.intel.com/edge/partners/advantech/
2) Click on "Run Safety-Gear Detection Sample" and open the notebook
3) After we submit a job, while clicking on "Telemetry Button", it was not opening up the dashboard.

Solved this issue by changing control_widgets.py and making required changes in "addTelemetryButton" and "displayTelemetry" function. Now using widgets.Output() for telemetry_out variable. 

Thank you.