### PR TITLE
Fixed LiveQstat bug

### DIFF
--- a/qarpo/demoutils.py
+++ b/qarpo/demoutils.py
@@ -231,7 +231,7 @@ def liveQstat():
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     output,_ = p.communicate()
     now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    qstat = widgets.Output(layout={'width': '100%', 'height': '300px', 'border': '1px solid gray'})
+    qstat = widgets.Output(layout=widgets.Layout(width='100%', height='200px', border='1px solid gray', overflow_y='auto'))
     stop_signal_q = queue.Queue()
 
     def _work(qstat,stop_signal_q):
@@ -240,6 +240,7 @@ def liveQstat():
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
             output,_ = p.communicate()
             now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            qstat.outputs = tuple()
             qstat.append_stdout(now+'\n\n'+output.decode()+'\n\n\n')
             time.sleep(10.0)
             qstat.clear_output(wait=False)


### PR DESCRIPTION
LiveQstat() have two issues,
1. In JupyterLab it's not refreshing output box, just keeps appending the result of `qstat -n -1`
2. If number of jobs displayed by `qstat -n -1 ` is too many, scroller is not present for output box.
This pull request can resolve both of this issues.